### PR TITLE
Adds number of polls check with finite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "freezer_monitor"
 description = "Package for monitoring temperature in freezer"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     {name = "Kyle R. Wodzicki", email = "krwodzicki@gmail.com"},
 ]

--- a/src/freezer_monitor/display.py
+++ b/src/freezer_monitor/display.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 from threading import Thread, Timer, Lock, Event
 from subprocess import check_output
@@ -232,7 +231,6 @@ class DisplayButton(Thread):
                 self.timer.cancel()
             self.timer = Timer(self.timeout, self.event.clear)
             self.timer.start()
-            time.sleep(0.2)  # Quick sleep to prevent multiple very-fast clicks
 
         if self.timer:
             self.timer.cancel()


### PR DESCRIPTION
There was a issue with the first poll of a sensor returning NaN and thus right after a boot-up would get email about all NaN.

Have added a module variable MIN_NUM_POLL = 10 and an 'nn' class attribute to SHT30 that is incremented each time the poll() method is called. We now check that self.nn > MIN_NUM_POLL before checking average is finite.

Removes a time.sleep call in the display module on the button press handler.